### PR TITLE
Added possibility to define default selected filters using the url parameters

### DIFF
--- a/search-parts/src/models/IUrlFilter.ts
+++ b/search-parts/src/models/IUrlFilter.ts
@@ -1,0 +1,7 @@
+import { RefinementOperator } from "./ISearchResult";
+
+export interface IUrlFilter {
+    filterName: string;
+    filterOperator: RefinementOperator;
+    filterValues: string | string[];
+}

--- a/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/ISearchRefinersContainerProps.ts
+++ b/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/ISearchRefinersContainerProps.ts
@@ -22,6 +22,11 @@ export interface ISearchRefinersContainerProps {
   refinersConfiguration: IRefinerConfiguration[];
 
   /**
+   * List of the deafault selected filters (based on the url config parameters)
+   */
+  defaultSelectedRefinementFilters: IRefinementFilter[];
+
+  /**
    * The selected layout
    */
   selectedLayout: RefinersLayoutOption;

--- a/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/SearchRefinersContainer.tsx
+++ b/search-parts/src/webparts/searchRefiners/components/SearchRefinersContainer/SearchRefinersContainer.tsx
@@ -24,7 +24,7 @@ export default class SearchRefinersContainer extends React.Component<ISearchRefi
 
     this.state = {
       shouldResetFilters: false,
-      selectedRefinementFilters: [],
+      selectedRefinementFilters: props.defaultSelectedRefinementFilters,
       availableRefiners: []
     };
 
@@ -111,8 +111,7 @@ export default class SearchRefinersContainer extends React.Component<ISearchRefi
     if (nextProps.query !== this.props.query || !isEqual(this.props.themeVariant, nextProps.themeVariant)) {
 
       this.setState({
-        shouldResetFilters: true,
-        selectedRefinementFilters: []
+        shouldResetFilters: true
       });
 
     } else {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| Related issues?  | /

#### What's in this Pull Request?

This PR wast created based on [this](https://github.com/SharePoint/sp-dev-solutions/issues/323) question.

As a first set-up i added the possibility to add pre-selected filters in the url for the Checkbox and Date filter types. When the refiner web part is loaded, the url parameters are checked, processed, evaluated and sent to the search service. You can define the default refiners using the `filters` url parameter. This parameter should contain a JSON string with the different filters.

e.g. `filters=[{"filterName":"Department","filterValues":["HR","Legal"],"filterOperator":"or"}]`

 - filterName: the name of the refiner (also used in the configuration of the web part)
 - filterValues: Can be a string or an array of strings. 
 - filterOperator: is optional. If not provided, the operator from the web part configuration will be taken into account

##### filterValue
The filter value for the date range should be in the following format: 'range(date 1,date 2)':
 - Date 1: Should be an ISO formatted UTC date OR min
 - Date 2: Should be an ISO formatted UTC date OR max

The filter value for a the date fixed interval should have one of the following values:
 - yesterday
 - weekAgo
 - monthAgo
 - threeMonthsAgo
 - yearAgo
 - olderThanYear




#### Next steps
 - Add support for other refiner templates (file type, persona, ...)
 - Update documentation